### PR TITLE
More tweaks for Mac

### DIFF
--- a/macupdate.py
+++ b/macupdate.py
@@ -10,7 +10,7 @@ from Foundation import NSObject
 class Delegate(NSObject):
 
     def init(self):
-        self = super(Delegate, self).init()
+        self = objc.super(Delegate, self).init()
         try:
             objc.loadBundle('Sparkle', globals(), join(dirname(sys.executable), os.pardir, 'Frameworks', 'Sparkle.framework'))
             self.updater = SUUpdater.sharedUpdater()

--- a/setupwizardUI.py
+++ b/setupwizardUI.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'setupwizardUI.ui'
 #
-# Created: Fri May 22 02:40:47 2015
+# Created: Mon May 25 02:51:00 2015
 #      by: PyQt4 UI code generator 4.11.3
 #
 # WARNING! All changes made in this file will be lost!
@@ -26,7 +26,7 @@ except AttributeError:
 class Ui_SetupWizard(object):
     def setupUi(self, SetupWizard):
         SetupWizard.setObjectName(_fromUtf8("SetupWizard"))
-        SetupWizard.resize(554, 519)
+        SetupWizard.resize(560, 545)
         SetupWizard.setWizardStyle(QtGui.QWizard.ModernStyle)
         self.wizardPage1 = CustomQWizardPage()
         self.wizardPage1.setObjectName(_fromUtf8("wizardPage1"))
@@ -120,9 +120,9 @@ class Ui_SetupWizard(object):
         self.verticalLayout_3.addWidget(self.label_11)
         self.horizontalLayout_2 = QtGui.QHBoxLayout()
         self.horizontalLayout_2.setObjectName(_fromUtf8("horizontalLayout_2"))
-        self.label_12 = QtGui.QLabel(self.wizardPage3)
-        self.label_12.setObjectName(_fromUtf8("label_12"))
-        self.horizontalLayout_2.addWidget(self.label_12)
+        self.appconf = QtGui.QLabel(self.wizardPage3)
+        self.appconf.setObjectName(_fromUtf8("appconf"))
+        self.horizontalLayout_2.addWidget(self.appconf)
         self.appconf_found = QtGui.QLabel(self.wizardPage3)
         self.appconf_found.setObjectName(_fromUtf8("appconf_found"))
         self.horizontalLayout_2.addWidget(self.appconf_found)
@@ -145,15 +145,15 @@ class Ui_SetupWizard(object):
         spacerItem1 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
         self.horizontalLayout_4.addItem(spacerItem1)
         self.verticalLayout_3.addLayout(self.horizontalLayout_4)
-        self.label_16 = QtGui.QLabel(self.wizardPage3)
+        self.advice = QtGui.QLabel(self.wizardPage3)
         font = QtGui.QFont()
         font.setPointSize(12)
-        self.label_16.setFont(font)
-        self.label_16.setTextFormat(QtCore.Qt.RichText)
-        self.label_16.setWordWrap(True)
-        self.label_16.setOpenExternalLinks(True)
-        self.label_16.setObjectName(_fromUtf8("label_16"))
-        self.verticalLayout_3.addWidget(self.label_16)
+        self.advice.setFont(font)
+        self.advice.setTextFormat(QtCore.Qt.RichText)
+        self.advice.setWordWrap(True)
+        self.advice.setOpenExternalLinks(True)
+        self.advice.setObjectName(_fromUtf8("advice"))
+        self.verticalLayout_3.addWidget(self.advice)
         SetupWizard.addPage(self.wizardPage3)
         self.wizardPage4 = CustomQWizardPage()
         self.wizardPage4.setObjectName(_fromUtf8("wizardPage4"))
@@ -235,12 +235,12 @@ class Ui_SetupWizard(object):
         self.wizardPage3.setTitle(_translate("SetupWizard", "Setup Wizard", None))
         self.wizardPage3.setSubTitle(_translate("SetupWizard", "Verbose Logging", None))
         self.label_11.setText(_translate("SetupWizard", "In order to automatically receive system and station names it is necessary to enable verbose logging in games settings files.", None))
-        self.label_12.setText(_translate("SetupWizard", "AppConfig.xml", None))
+        self.appconf.setText(_translate("SetupWizard", "AppConfig.xml", None))
         self.appconf_found.setText(_translate("SetupWizard", "-", None))
         self.label_14.setText(_translate("SetupWizard", "Verbose Logging", None))
         self.verbose_enabled.setText(_translate("SetupWizard", "-", None))
         self.verbose_button.setText(_translate("SetupWizard", "Enable Verbose Logging", None))
-        self.label_16.setText(_translate("SetupWizard", "<html><head/><body><p>After enabling verbose logging in ED <span style=\" font-weight:600; text-decoration: underline;\">restart the game</span> and make some good market screenshots for calibration. You make the screenshots by pressing F10 in the game. DO NOT use ALT+F10.<br/><br/>Exaple of a <a href=\"http://i.imgur.com/n2UPagt.jpg\"><span style=\" text-decoration: underline; color:#0000ff;\">good screenshot</span></a> and an exaple of a <a href=\"http://i.imgur.com/MZTmTON.jpg\"><span style=\" text-decoration: underline; color:#0000ff;\">bad screenshot</span></a>.<br/><br/>Please note the selected line and the glow on the top of the market frame. You have to make sure they are not present on your screenshots. You can achieve this by moving the mouse to the right on the field with commodity description or by pressing right on your jostick/gamepad until this field is selected.</p><p>(You can keep this wizard open while you make the screenshots.)</p></body></html>", None))
+        self.advice.setText(_translate("SetupWizard", "<html><head/><body><p>After enabling verbose logging in ED <span style=\" font-weight:600; text-decoration: underline;\">restart the game</span> and make some good market screenshots for calibration. You make the screenshots by pressing %1 in the game. DO NOT use Alt-%1. %2</p><p>Example of a <a href=\"http://i.imgur.com/n2UPagt.jpg\"><span style=\" text-decoration: underline; color:#0000ff;\">good screenshot</span></a> and an example of a <a href=\"http://i.imgur.com/MZTmTON.jpg\"><span style=\" text-decoration: underline; color:#0000ff;\">bad screenshot</span></a>.</p><p>Please note the selected line and the glow on the top of the market frame. You have to make sure they are not present on your screenshots. You can achieve this by moving the mouse to the right on the field with commodity description or by pressing right on your joystick/gamepad until this field is selected.</p><p>(You can keep this wizard open while you make the screenshots.)</p></body></html>", None))
         self.wizardPage4.setTitle(_translate("SetupWizard", "Setup Wizard", None))
         self.wizardPage4.setSubTitle(_translate("SetupWizard", "Screenshot and Export paths", None))
         self.label_17.setText(_translate("SetupWizard", "In this step you choose where EliteOCR should look for screenshots and where you want it to export your results.", None))

--- a/setupwizardUI.ui
+++ b/setupwizardUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>554</width>
-    <height>519</height>
+    <width>560</width>
+    <height>545</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -220,7 +220,7 @@ Please read all the instructions very carefully. You can run this wizard at any 
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="appconf">
         <property name="text">
          <string>AppConfig.xml</string>
         </property>
@@ -281,14 +281,14 @@ Please read all the instructions very carefully. You can run this wizard at any 
      </layout>
     </item>
     <item>
-     <widget class="QLabel" name="label_16">
+     <widget class="QLabel" name="advice">
       <property name="font">
        <font>
         <pointsize>12</pointsize>
        </font>
       </property>
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After enabling verbose logging in ED &lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;restart the game&lt;/span&gt; and make some good market screenshots for calibration. You make the screenshots by pressing F10 in the game. DO NOT use ALT+F10.&lt;br/&gt;&lt;br/&gt;Exaple of a &lt;a href=&quot;http://i.imgur.com/n2UPagt.jpg&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;good screenshot&lt;/span&gt;&lt;/a&gt; and an exaple of a &lt;a href=&quot;http://i.imgur.com/MZTmTON.jpg&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;bad screenshot&lt;/span&gt;&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Please note the selected line and the glow on the top of the market frame. You have to make sure they are not present on your screenshots. You can achieve this by moving the mouse to the right on the field with commodity description or by pressing right on your jostick/gamepad until this field is selected.&lt;/p&gt;&lt;p&gt;(You can keep this wizard open while you make the screenshots.)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After enabling verbose logging in ED &lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;restart the game&lt;/span&gt; and make some good market screenshots for calibration. You make the screenshots by pressing %1 in the game. DO NOT use Alt-%1. %2&lt;/p&gt;&lt;p&gt;Example of a &lt;a href=&quot;http://i.imgur.com/n2UPagt.jpg&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;good screenshot&lt;/span&gt;&lt;/a&gt; and an example of a &lt;a href=&quot;http://i.imgur.com/MZTmTON.jpg&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;bad screenshot&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Please note the selected line and the glow on the top of the market frame. You have to make sure they are not present on your screenshots. You can achieve this by moving the mouse to the right on the field with commodity description or by pressing right on your joystick/gamepad until this field is selected.&lt;/p&gt;&lt;p&gt;(You can keep this wizard open while you make the screenshots.)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="textFormat">
        <enum>Qt::RichText</enum>


### PR DESCRIPTION
Mac users seem to struggle with taking screenshots in the Elite Dangerous client. This change adds some advice to the settings wizard on the user's Keyboard preferences.

Also enlarges the settings wizard slightly to fit text on Windows with system text size set to "Medium - 125%" and on Mac.

![screen shot 2015-05-25 at 12 57 57](https://cloud.githubusercontent.com/assets/1374740/7796986/c53de622-02dd-11e5-8611-eba91f09fe94.png)