### PR TITLE
Store user training data separately from executable on Mac and Linux.

### DIFF
--- a/EliteOCR.py
+++ b/EliteOCR.py
@@ -212,7 +212,7 @@ class EliteOCR(QMainWindow, Ui_MainWindow):
             self.openCalibration()
             self.settings.setValue('first_run', False)
         else:
-            datapath = (self.settings.app_path + os.sep + "trainingdata" + os.sep + "user_station.xml").encode(sys.getfilesystemencoding())
+            datapath = (self.settings.storage_path + os.sep + "user_station.xml").encode(sys.getfilesystemencoding())
             if not isfile(datapath):
                 msg = _translate("EliteOCR", "It appears you did not train EliteOCR. Training is essential in order to minimize the amount of OCR errors. Would you like to start the Learning Wizard now?", None)
                 if QMessageBox.question(self, 'Training', msg, _translate("EliteOCR","Yes", None), _translate("EliteOCR","No", None)) == 0:
@@ -1242,6 +1242,8 @@ def main(argv):
         global gui
         gui = True
         app = QApplication(sys.argv)
+        app.setOrganizationName('seeebek')
+        app.setApplicationName('eliteOCR')
         qtTranslator = QTranslator()
         translateApp(app, qtTranslator)
 

--- a/aboutUI.py
+++ b/aboutUI.py
@@ -89,7 +89,7 @@ class Ui_About(object):
         self.label.setText(_translate("About", "\n"
 "\n"
 "Contributors:\n"
-"Seeebek, Marginal, CapCap, Gazelle, GMib, Marginal, Ph.Baumann\n"
+"Seeebek, Marginal, CapCap, Gazelle, GMib, Ph.Baumann\n"
 "\n"
 "EliteOCR is capable of reading the entries in Elite: Dangerous markets screenshots.", None))
 

--- a/calibrator.py
+++ b/calibrator.py
@@ -116,7 +116,7 @@ class Calibrator(QThread):
         img = 255 - img
         #cv2.imshow("x", img)
         #cv2.waitKey(0)
-        mlp = MLP(img, self.settings.app_path, self.ocr_areas.areas, isstation=False, calibration=True)
+        mlp = MLP(img, self.settings, self.ocr_areas.areas, isstation=False, calibration=True)
         #print market.result
         #for result in market.result:
         #    print result.name.value

--- a/engine.py
+++ b/engine.py
@@ -153,7 +153,7 @@ class OCRAreasFinder:
         return new_areas
         
 class MLP:
-    def __init__(self, image, path, areas, isstation, calibration = False):
+    def __init__(self, image, settings, areas, isstation, calibration = False):
         #full old
         """
         layers = np.array([400,32,46])
@@ -164,10 +164,10 @@ class MLP:
         #numbers
         
         if isstation:
-            self.station = TrainedDataStation(path)
+            self.station = TrainedDataStation(settings)
         else:
-            self.numbers = TrainedDataNumbers(path)
-            self.letters = TrainedDataLetters(path)
+            self.numbers = TrainedDataNumbers(settings)
+            self.letters = TrainedDataLetters(settings)
         """
         layers = np.array([400,36,12])
         self.nnetwork = cv2.ANN_MLP(layers, 1,0.6,1)
@@ -703,45 +703,45 @@ class OCRbox():
             self.boxes.append(self.box)
         
 class TrainedDataNumbers():
-    def __init__(self, path):
+    def __init__(self, settings):
         self.revclassdict = {"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,",":10,"-":11}
         self.keys = len(self.revclassdict)
         layers = np.array([400,71,self.keys])
         self.nnetwork = cv2.ANN_MLP(layers, 1,0.65,1)
-        datapath = (path + os.sep + "trainingdata" + os.sep + "user_numbers.xml").encode(sys.getfilesystemencoding())
+        datapath = (settings.storage_path + os.sep + "user_numbers.xml").encode(sys.getfilesystemencoding())
         if isfile(datapath):
             self.nnetwork.load(datapath, "OCRMLP")
         else:
-            datapath = (path + os.sep + "numbers.xml").encode(sys.getfilesystemencoding())
+            datapath = (settings.app_path + os.sep + "numbers.xml").encode(sys.getfilesystemencoding())
             self.nnetwork.load(datapath, "OCRMLP")
         self.classdict = dict((v,k.decode("utf-8")) for k,v in self.revclassdict.iteritems())
         
         
 class TrainedDataLetters():
-    def __init__(self, path):
+    def __init__(self, settings):
         self.revclassdict = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"-":26,".":27,"'":28}
         self.keys = len(self.revclassdict)
         layers = np.array([400,71,self.keys])
         self.nnetwork = cv2.ANN_MLP(layers, 1,0.65,1)
-        datapath = (path + os.sep + "trainingdata" + os.sep + "user_letters.xml").encode(sys.getfilesystemencoding())
+        datapath = (settings.storage_path + os.sep + "user_letters.xml").encode(sys.getfilesystemencoding())
         if isfile(datapath):
             self.nnetwork.load(datapath, "OCRMLP")
         else:
-            datapath = (path + os.sep + "letters.xml").encode(sys.getfilesystemencoding())
+            datapath = (settings.app_path + os.sep + "letters.xml").encode(sys.getfilesystemencoding())
             self.nnetwork.load(datapath, "OCRMLP")
         self.classdict = dict((v,k.decode("utf-8")) for k,v in self.revclassdict.iteritems())
         
 class TrainedDataStation():
-    def __init__(self, path):
+    def __init__(self, settings):
         self.revclassdict = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"1":26,"2":27,"3":28,"4":29,"5":30,"6":31,"7":32,"8":33,"9":34,"-":35,".":36,"'":37,"&":38,"[":39,"]":40}
         self.keys = len(self.revclassdict)
         layers = np.array([400,71,self.keys])
         self.nnetwork = cv2.ANN_MLP(layers, 1,0.65,1)
-        datapath = (path + os.sep + "trainingdata" + os.sep + "user_station.xml").encode(sys.getfilesystemencoding())
+        datapath = (settings.storage_path + os.sep + "user_station.xml").encode(sys.getfilesystemencoding())
         if isfile(datapath):
             self.nnetwork.load(datapath, "OCRMLP")
         else:
-            datapath = (path + os.sep + "station.xml").encode(sys.getfilesystemencoding())
+            datapath = (settings.app_path + os.sep + "station.xml").encode(sys.getfilesystemencoding())
             self.nnetwork.load(datapath, "OCRMLP")
         self.classdict = dict((v,k.decode("utf-8")) for k,v in self.revclassdict.iteritems())        
         

--- a/learningwizard.py
+++ b/learningwizard.py
@@ -79,7 +79,7 @@ class LearningWizard(QWizard, Ui_Wizard):
         
     def deleteUserImages(self):
         self.user = None
-        path = self.settings.app_path+os.sep+"trainingdata"+os.sep+"user_training_data.pck"
+        path = self.settings.storage_path+os.sep+"user_training_data.pck"
         remove(path)
         self.user_data_label.setText("-")
         self.delete_images_button.setEnabled(False)
@@ -202,7 +202,7 @@ class LearningWizard(QWizard, Ui_Wizard):
                     else:
                         self.user[letter[1]] = data
                     
-        path = self.settings.app_path+os.sep+"trainingdata"+os.sep+"user_training_data.pck"
+        path = self.settings.storage_path+os.sep+"user_training_data.pck"
         file = gzip.GzipFile(path, 'wb')
         pickle.dump(self.user, file,-1)
         file.close()
@@ -249,7 +249,7 @@ class LearningWizard(QWizard, Ui_Wizard):
         
     def loadUser(self):
         try:
-            path = self.settings.app_path+os.sep+"trainingdata"+os.sep+"user_training_data.pck"
+            path = self.settings.storage_path+os.sep+"user_training_data.pck"
             file = gzip.GzipFile(path, 'rb')
             letters = pickle.load(file)
             file.close()

--- a/ocr.py
+++ b/ocr.py
@@ -30,12 +30,12 @@ class OCR():
         self.commodities = self.readMarket(levels, levenshtein)
 
     def readStationName(self):
-        station = MLP(self.station_img, self.settings.app_path, self.ocr_areas.areas, isstation=True)
+        station = MLP(self.station_img, self.settings, self.ocr_areas.areas, isstation=True)
         #print station.result[0].name
         return station.result[0]
         
     def readMarket(self, levels, levenshtein = True):
-        market = MLP(self.commodities_img, self.settings.app_path, self.ocr_areas.areas, isstation=False)
+        market = MLP(self.commodities_img, self.settings, self.ocr_areas.areas, isstation=False)
         #for line in market.result:
         #    print line.name
         if levenshtein:

--- a/settings.py
+++ b/settings.py
@@ -237,7 +237,7 @@ class Settings():
     def getPathToStorage(self):
         """Return the path to a place for writing supporting files"""
         if platform=='win32':
-            path = join(getPathToSelf(), "trainingdata")	# Store writable data alongside executable
+            path = join(self.getPathToSelf(), "trainingdata")	# Store writable data alongside executable
         else:
             path = unicode(QDesktopServices.storageLocation(QDesktopServices.DataLocation))
         if not isdir(path):

--- a/settings.py
+++ b/settings.py
@@ -2,7 +2,7 @@
 import sys
 import random
 import os
-from os import environ, listdir
+from os import environ, listdir, makedirs
 from os.path import isfile, isdir, basename, dirname, join, normpath
 from sys import platform
 from PyQt4.QtCore import QSettings, QString, QT_VERSION
@@ -23,8 +23,9 @@ class Settings():
     def __init__(self, parent=None):
         self.parent = parent
         self.app_path = self.getPathToSelf()
+        self.storage_path = self.getPathToStorage()
         self.values = {}
-        self.reg = QSettings('seeebek', 'eliteOCR')
+        self.reg = QSettings()	# uses QCoreApplication.organizationName and applicationName
         self.userprofile = self.getUserProfile()
         if self.reg.contains('settings_version'):
             if float(self.reg.value('settings_version', type=QString)) < 1.6:
@@ -232,6 +233,16 @@ class Settings():
         else:
             application_path = u"."
         return application_path
+
+    def getPathToStorage(self):
+        """Return the path to a place for writing supporting files"""
+        if platform=='win32':
+            path = join(getPathToSelf(), "trainingdata")	# Store writable data alongside executable
+        else:
+            path = unicode(QDesktopServices.storageLocation(QDesktopServices.DataLocation))
+        if not isdir(path):
+            makedirs(path)
+        return path
 
 
 # AppConfig helpers

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,9 @@ OPTIONS = {'semi_standalone': True,
            'optimize': 2,
            'resources': [qt_conf,	# http://doc.qt.io/qt-4.8/qt-conf.html
                          'plugins',	# for TD_Export
-                         'translations', 'letters.xml', 'numbers.xml', 'station.xml', 'help', 'trainingdata', 'commodities.json'],
+                         'translations', 'letters.xml', 'numbers.xml', 'station.xml', 'help', 'commodities.json',
+                         ('trainingdata', ['trainingdata/base_training_data.pck', 'trainingdata/README'])
+                     ],
            'includes': ['PyQt4.QtNetwork'],
            'include_plugins': ['/Developer/Applications/Qt/plugins/imageformats/libqgif.dylib', '/Developer/Applications/Qt/plugins/imageformats/libqico.dylib'],
            'excludes': ['PIL', 'setuptools', 'matplotlib', 'wx',	# random modules that tend to get picked up

--- a/trainer.py
+++ b/trainer.py
@@ -42,7 +42,7 @@ class Trainer(QThread):
         classdict = {"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,",":10,"-":11}
         nnetwork = self.trainProcess(classdict)
         if not nnetwork is None:
-            nnetwork.save((self.settings.app_path + os.sep + "trainingdata" + os.sep +"user_numbers.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
+            nnetwork.save((self.settings.storage_path + os.sep +"user_numbers.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
             
             resultcheck = self.testProcess(classdict, self.testnumbers)
             if not resultcheck is None:
@@ -54,7 +54,7 @@ class Trainer(QThread):
         classdict = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"-":26,",":27,"'":28}
         nnetwork = self.trainProcess(classdict)
         if not nnetwork is None:
-            nnetwork.save((self.settings.app_path + os.sep + "trainingdata" + os.sep + "user_letters.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
+            nnetwork.save((self.settings.storage_path + os.sep + "user_letters.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
             
             resultcheck = self.testProcess(classdict, self.testletters)
             if not resultcheck is None:
@@ -66,7 +66,7 @@ class Trainer(QThread):
         classdict = {"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"1":26,"2":27,"3":28,"4":29,"5":30,"6":31,"7":32,"8":33,"9":34,"-":35,",":36,"'":37,"&":38,"[":39,"]":40}
         nnetwork = self.trainProcess(classdict)
         if not nnetwork is None:
-            nnetwork.save((self.settings.app_path + os.sep + "trainingdata" + os.sep + "user_station.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
+            nnetwork.save((self.settings.storage_path + os.sep + "user_station.xml").encode(sys.getfilesystemencoding()), "OCRMLP")
             
             resultcheck = self.testProcess(classdict, self.teststation)
             if not resultcheck is None:


### PR DESCRIPTION
Your change 2f1ccb1 flagged up a problem on Mac that I had previously missed - the application folder is not generally writeable on Macs, so user training data was not being saved and/or was being deleted on app update.
This patch fixes this by storing user training data separately from the base training data on Mac and Linux. Windows *should* be unchanged.
I've tested this reasonably thoroughly, but please review before I release 0.7 on Mac.
